### PR TITLE
Namespace 機能の実装

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,11 +217,40 @@ Named pipe（FIFO）として指定パスに仮想`.env`ファイルを作成す
 - 読み取りのたびに動的に復号（キャッシュなし）
 - serve中に期限切れを検出した場合はstderrに警告を出力
 
+## Namespace
+
+プロジェクトごとにデータベースと監査ログを分離できる。
+
+```
+~/.torii/
+  default/        # デフォルト namespace
+    torii.db
+    audit.log
+  myproject/      # カスタム namespace
+    torii.db
+    audit.log
+```
+
+### 使い方
+
+```
+torii -n myproject set API_KEY=xxx    # myproject namespace に保存
+torii -n myproject get API_KEY        # myproject namespace から取得
+torii namespaces                      # namespace 一覧表示
+```
+
+- `--db-path` 未指定時、データベースは `~/.torii/<namespace>/torii.db` に保存される
+- namespace ごとにパスワードは独立（別々のDEK）
+- namespace 間のデータは完全に分離されている
+- `--db-path` を明示指定した場合、namespace は無視される
+- namespace 名は英数字、ハイフン、アンダースコアのみ使用可能
+
 ## オプション
 
 | フラグ | 説明 | デフォルト |
 |---|---|---|
-| `--db-path <path>` | SQLiteデータベースのパス | `torii.db` |
+| `--db-path <path>` | SQLiteデータベースのパス（namespace を上書き） | `~/.torii/default/torii.db` |
+| `-n, --namespace <name>` | namespace 名 | `default` |
 | `--expires <duration>` | 有効期限（`set`時） | なし |
 | `-e, --env-path <path>` | 仮想.envのパス（`serve`時） | `.env` |
 | `--once` | 1回読まれたら終了（`serve`時） | off |

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -6,9 +6,13 @@ use clap::{Parser, Subcommand};
     about = "Protect environment variables with hybrid PQC encryption"
 )]
 pub struct Cli {
-    /// Path to the SQLite database file
-    #[arg(long, default_value = "torii.db")]
-    pub db_path: String,
+    /// Path to the SQLite database file (overrides --namespace)
+    #[arg(long)]
+    pub db_path: Option<String>,
+
+    /// Namespace for isolating databases
+    #[arg(short = 'n', long, default_value = "default")]
+    pub namespace: String,
 
     /// Path to the audit log file
     #[arg(long)]
@@ -68,6 +72,9 @@ pub enum Commands {
 
     /// Rotate DEK (generate new DEK and re-encrypt all values)
     RotateDek,
+
+    /// List all namespaces
+    Namespaces,
 
     /// View audit logs
     Logs {

--- a/src/logger.rs
+++ b/src/logger.rs
@@ -9,7 +9,8 @@ use crate::error::{EnvsGateError, Result};
 
 const MAX_LOG_SIZE: u64 = 10 * 1024 * 1024; // 10MB
 
-/// Default log path
+/// Default log path (used as fallback)
+#[cfg(test)]
 pub fn default_log_path() -> String {
     if cfg!(target_os = "macos") || cfg!(target_os = "linux") {
         let home = std::env::var("HOME").unwrap_or_else(|_| "/tmp".into());

--- a/src/main.rs
+++ b/src/main.rs
@@ -75,9 +75,33 @@ fn resolve_paths(
     })?;
 
     let db = format!("{ns_dir}/torii.db");
-    let log = log_path
-        .clone()
-        .unwrap_or_else(|| format!("{ns_dir}/audit.log"));
+
+    // P1: Warn if CWD has a legacy torii.db but namespace DB doesn't exist yet
+    if namespace == "default" && !std::path::Path::new(&db).exists() {
+        let legacy_db = std::path::Path::new("torii.db");
+        if legacy_db.exists() {
+            eprintln!(
+                "Warning: Found ./torii.db in current directory, but default namespace DB does not exist yet."
+            );
+            eprintln!("  To use the existing DB: torii --db-path ./torii.db <command>");
+            eprintln!("  To migrate: mv ./torii.db {db}");
+        }
+    }
+
+    // P2: Migrate legacy audit log (~/.torii/audit.log → ~/.torii/default/audit.log)
+    let ns_log = format!("{ns_dir}/audit.log");
+    if namespace == "default" && !std::path::Path::new(&ns_log).exists() {
+        let legacy_log = format!("{torii_home}/audit.log");
+        if std::path::Path::new(&legacy_log).exists() {
+            if let Err(e) = std::fs::rename(&legacy_log, &ns_log) {
+                eprintln!("Warning: Failed to migrate audit log: {e}");
+            } else {
+                eprintln!("Migrated audit log: {legacy_log} → {ns_log}");
+            }
+        }
+    }
+
+    let log = log_path.clone().unwrap_or(ns_log);
 
     Ok((db, log))
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -33,10 +33,53 @@ fn prompt_new_password() -> error::Result<String> {
         .map_err(|e| error::EnvsGateError::InvalidInput(format!("Password prompt failed: {e}")))
 }
 
-fn resolve_log_path(cli_log_path: &Option<String>) -> String {
-    cli_log_path
+fn validate_namespace(ns: &str) -> error::Result<()> {
+    if ns.is_empty() || ns == "." || ns == ".." {
+        return Err(error::EnvsGateError::InvalidInput(
+            "Invalid namespace name".into(),
+        ));
+    }
+    if !ns
+        .chars()
+        .all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_')
+    {
+        return Err(error::EnvsGateError::InvalidInput(
+            "Namespace must contain only alphanumeric characters, hyphens, and underscores".into(),
+        ));
+    }
+    Ok(())
+}
+
+fn torii_home() -> error::Result<String> {
+    let home = std::env::var("HOME")
+        .map_err(|_| error::EnvsGateError::InvalidInput("HOME not set".into()))?;
+    Ok(format!("{home}/.torii"))
+}
+
+fn resolve_paths(
+    db_path: &Option<String>,
+    namespace: &str,
+    log_path: &Option<String>,
+) -> error::Result<(String, String)> {
+    if let Some(db) = db_path {
+        // Explicit db-path: ignore namespace
+        let log = log_path.clone().unwrap_or_else(logger::default_log_path);
+        return Ok((db.clone(), log));
+    }
+
+    validate_namespace(namespace)?;
+    let torii_home = torii_home()?;
+    let ns_dir = format!("{torii_home}/{namespace}");
+    std::fs::create_dir_all(&ns_dir).map_err(|e| {
+        error::EnvsGateError::InvalidInput(format!("Cannot create namespace directory: {e}"))
+    })?;
+
+    let db = format!("{ns_dir}/torii.db");
+    let log = log_path
         .clone()
-        .unwrap_or_else(logger::default_log_path)
+        .unwrap_or_else(|| format!("{ns_dir}/audit.log"));
+
+    Ok((db, log))
 }
 
 fn open_logger(log_path: &str) -> error::Result<logger::Logger> {
@@ -62,15 +105,21 @@ fn unwrap_dek_logged(
 
 fn main() -> error::Result<()> {
     let cli = Cli::parse();
-    let log_path = resolve_log_path(&cli.log_path);
+
+    // Handle namespaces command before resolving paths (no DB needed)
+    if matches!(cli.command, Some(Commands::Namespaces)) {
+        return cmd_namespaces();
+    }
+
+    let (db_path, log_path) = resolve_paths(&cli.db_path, &cli.namespace, &cli.log_path)?;
     let mut log = Some(open_logger(&log_path)?);
 
     match cli.command {
-        None => return tui::run_interactive(&cli.db_path, Some(&log_path)),
+        None => return tui::run_interactive(&db_path, Some(&log_path)),
         Some(Commands::Set { key_value, expires }) => {
             let mut password = prompt_password()?;
             let result = cmd_set(
-                &cli.db_path,
+                &db_path,
                 &password,
                 &key_value,
                 expires.as_deref(),
@@ -81,31 +130,31 @@ fn main() -> error::Result<()> {
         }
         Some(Commands::Get { key }) => {
             let mut password = prompt_password()?;
-            let result = cmd_get(&cli.db_path, &password, &key, &mut log);
+            let result = cmd_get(&db_path, &password, &key, &mut log);
             password.zeroize();
             result?;
         }
         Some(Commands::List) => {
             let mut password = prompt_password()?;
-            let result = cmd_list(&cli.db_path, &password, &mut log);
+            let result = cmd_list(&db_path, &password, &mut log);
             password.zeroize();
             result?;
         }
         Some(Commands::Delete { key }) => {
             let mut password = prompt_password()?;
-            let result = cmd_delete(&cli.db_path, &password, &key, &mut log);
+            let result = cmd_delete(&db_path, &password, &key, &mut log);
             password.zeroize();
             result?;
         }
         Some(Commands::Serve { env_path, once }) => {
             let mut password = prompt_password()?;
-            let result = cmd_serve(&cli.db_path, &password, &env_path, once, &mut log);
+            let result = cmd_serve(&db_path, &password, &env_path, once, &mut log);
             password.zeroize();
             result?;
         }
         Some(Commands::Exec { command }) => {
             let mut password = prompt_password()?;
-            let result = cmd_exec(&cli.db_path, &password, &command, &mut log);
+            let result = cmd_exec(&db_path, &password, &command, &mut log);
             password.zeroize();
             let code = result?;
             std::process::exit(code);
@@ -114,17 +163,18 @@ fn main() -> error::Result<()> {
             let old_password = prompt_password_with_message("Old password: ")?;
             let mut new_password = prompt_new_password()?;
             let mut old_pw = old_password;
-            let result = cmd_rotate_password(&cli.db_path, &old_pw, &new_password, &mut log);
+            let result = cmd_rotate_password(&db_path, &old_pw, &new_password, &mut log);
             old_pw.zeroize();
             new_password.zeroize();
             result?;
         }
         Some(Commands::RotateDek) => {
             let mut password = prompt_password()?;
-            let result = cmd_rotate_dek(&cli.db_path, &password, &mut log);
+            let result = cmd_rotate_dek(&db_path, &password, &mut log);
             password.zeroize();
             result?;
         }
+        Some(Commands::Namespaces) => unreachable!(),
         Some(Commands::Logs { format }) => {
             let fmt = match format.as_str() {
                 "json" => logger::LogFormat::Json,
@@ -480,6 +530,38 @@ pub fn cmd_exec(
     Ok(status
         .code()
         .unwrap_or_else(|| status.signal().map_or(1, |sig| 128 + sig)))
+}
+
+pub fn cmd_namespaces() -> error::Result<()> {
+    let torii_home = torii_home()?;
+    let path = std::path::Path::new(&torii_home);
+
+    if !path.exists() {
+        eprintln!("No namespaces found.");
+        return Ok(());
+    }
+
+    let mut entries: Vec<String> = std::fs::read_dir(path)
+        .map_err(|e| error::EnvsGateError::InvalidInput(format!("Cannot read directory: {e}")))?
+        .filter_map(|e| e.ok())
+        .filter(|e| e.path().is_dir() && e.path().join("torii.db").exists())
+        .filter_map(|e| e.file_name().into_string().ok())
+        .collect();
+    entries.sort();
+
+    if entries.is_empty() {
+        eprintln!("No namespaces found.");
+    } else {
+        for ns in &entries {
+            if ns == "default" {
+                println!("{ns} (default)");
+            } else {
+                println!("{ns}");
+            }
+        }
+    }
+
+    Ok(())
 }
 
 pub fn cmd_rotate_password(
@@ -1080,6 +1162,91 @@ mod tests {
             serde_json::from_str(content.lines().next().unwrap()).unwrap();
         assert_eq!(entry.action, "rotate_dek");
         assert!(entry.detail.unwrap().contains("reencrypted=2"));
+    }
+
+    // --- namespace テスト ---
+
+    #[test]
+    fn validate_namespace_valid() {
+        assert!(validate_namespace("default").is_ok());
+        assert!(validate_namespace("my-project").is_ok());
+        assert!(validate_namespace("project_1").is_ok());
+        assert!(validate_namespace("ABC123").is_ok());
+    }
+
+    #[test]
+    fn validate_namespace_invalid() {
+        assert!(validate_namespace("").is_err());
+        assert!(validate_namespace(".").is_err());
+        assert!(validate_namespace("..").is_err());
+        assert!(validate_namespace("foo/bar").is_err());
+        assert!(validate_namespace("foo bar").is_err());
+        assert!(validate_namespace("a@b").is_err());
+    }
+
+    #[test]
+    fn resolve_paths_explicit_db_path_ignores_namespace() {
+        let (db, _log) = resolve_paths(&Some("./custom.db".into()), "myproject", &None).unwrap();
+        assert_eq!(db, "./custom.db");
+    }
+
+    #[test]
+    fn resolve_paths_namespace_creates_dir() {
+        let dir = tempfile::tempdir().unwrap();
+        let home = dir.path().to_str().unwrap();
+        unsafe { std::env::set_var("HOME", home) };
+
+        let (db, log) = resolve_paths(&None, "testns", &None).unwrap();
+
+        assert!(db.contains("/.torii/testns/torii.db"));
+        assert!(log.contains("/.torii/testns/audit.log"));
+        assert!(std::path::Path::new(&format!("{home}/.torii/testns")).is_dir());
+    }
+
+    #[test]
+    fn resolve_paths_explicit_log_path_overrides() {
+        let dir = tempfile::tempdir().unwrap();
+        let home = dir.path().to_str().unwrap();
+        unsafe { std::env::set_var("HOME", home) };
+
+        let (_, log) = resolve_paths(&None, "default", &Some("/tmp/custom.log".into())).unwrap();
+        assert_eq!(log, "/tmp/custom.log");
+    }
+
+    #[test]
+    fn resolve_paths_invalid_namespace_fails() {
+        assert!(resolve_paths(&None, "../escape", &None).is_err());
+        assert!(resolve_paths(&None, "", &None).is_err());
+    }
+
+    #[test]
+    fn cmd_namespaces_with_no_dir() {
+        let dir = tempfile::tempdir().unwrap();
+        let home = dir.path().to_str().unwrap();
+        unsafe { std::env::set_var("HOME", home) };
+
+        // Should not error even if ~/.torii doesn't exist
+        assert!(cmd_namespaces().is_ok());
+    }
+
+    #[test]
+    fn cmd_namespaces_lists_existing() {
+        let dir = tempfile::tempdir().unwrap();
+        let home = dir.path().to_str().unwrap();
+        unsafe { std::env::set_var("HOME", home) };
+
+        // Create namespace directories with DBs
+        let ns1 = format!("{home}/.torii/alpha");
+        let ns2 = format!("{home}/.torii/beta");
+        let ns_empty = format!("{home}/.torii/empty");
+        std::fs::create_dir_all(&ns1).unwrap();
+        std::fs::create_dir_all(&ns2).unwrap();
+        std::fs::create_dir_all(&ns_empty).unwrap();
+        std::fs::write(format!("{ns1}/torii.db"), b"").unwrap();
+        std::fs::write(format!("{ns2}/torii.db"), b"").unwrap();
+        // ns_empty has no torii.db, should not appear
+
+        assert!(cmd_namespaces().is_ok());
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -77,10 +77,11 @@ fn resolve_paths(
         // Explicit db-path: ignore namespace, place audit log next to DB
         let log = log_path.clone().unwrap_or_else(|| {
             let db_path = std::path::Path::new(db);
-            let dir = db_path
-                .parent()
-                .unwrap_or_else(|| std::path::Path::new("."));
-            format!("{}/audit.log", dir.display())
+            let dir = db_path.parent().filter(|p| !p.as_os_str().is_empty());
+            match dir {
+                Some(d) => format!("{}/audit.log", d.display()),
+                None => "audit.log".into(),
+            }
         });
         return Ok((db.clone(), log));
     }
@@ -599,7 +600,10 @@ pub fn cmd_namespaces() -> error::Result<()> {
     let mut entries: Vec<String> = std::fs::read_dir(path)
         .map_err(|e| error::EnvsGateError::InvalidInput(format!("Cannot read directory: {e}")))?
         .filter_map(|e| e.ok())
-        .filter(|e| e.path().is_dir() && e.path().join("torii.db").exists())
+        .filter(|e| {
+            let p = e.path();
+            p.is_dir() && (p.join("torii.db").exists() || p.join("audit.log").exists())
+        })
         .filter_map(|e| e.file_name().into_string().ok())
         .collect();
     entries.sort();
@@ -1266,7 +1270,6 @@ mod tests {
     fn resolve_paths_explicit_db_path_ignores_namespace() {
         let (db, log) = resolve_paths(&Some("./custom.db".into()), "myproject", &None).unwrap();
         assert_eq!(db, "./custom.db");
-        // Log should be placed next to the DB
         assert_eq!(log, "./audit.log");
     }
 
@@ -1275,6 +1278,14 @@ mod tests {
         let (_, log) =
             resolve_paths(&Some("/tmp/mydir/vault.db".into()), "default", &None).unwrap();
         assert_eq!(log, "/tmp/mydir/audit.log");
+    }
+
+    #[test]
+    fn resolve_paths_bare_filename_db_path() {
+        // bare filename like "custom.db" — parent is empty, log should be "audit.log" in CWD
+        let (db, log) = resolve_paths(&Some("custom.db".into()), "default", &None).unwrap();
+        assert_eq!(db, "custom.db");
+        assert_eq!(log, "audit.log");
     }
 
     #[test]
@@ -1322,16 +1333,19 @@ mod tests {
         let home = dir.path().to_str().unwrap();
         unsafe { std::env::set_var("HOME", home) };
 
-        // Create namespace directories with DBs
+        // Create namespace directories
         let ns1 = format!("{home}/.torii/alpha");
         let ns2 = format!("{home}/.torii/beta");
+        let ns_log_only = format!("{home}/.torii/gamma");
         let ns_empty = format!("{home}/.torii/empty");
         std::fs::create_dir_all(&ns1).unwrap();
         std::fs::create_dir_all(&ns2).unwrap();
+        std::fs::create_dir_all(&ns_log_only).unwrap();
         std::fs::create_dir_all(&ns_empty).unwrap();
         std::fs::write(format!("{ns1}/torii.db"), b"").unwrap();
         std::fs::write(format!("{ns2}/torii.db"), b"").unwrap();
-        // ns_empty has no torii.db, should not appear
+        std::fs::write(format!("{ns_log_only}/audit.log"), b"").unwrap();
+        // ns_empty has neither torii.db nor audit.log, should not appear
 
         assert!(cmd_namespaces().is_ok());
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -55,9 +55,16 @@ fn validate_namespace(ns: &str) -> error::Result<()> {
     Ok(())
 }
 
+fn home_dir() -> error::Result<String> {
+    std::env::var("HOME")
+        .or_else(|_| std::env::var("USERPROFILE"))
+        .map_err(|_| {
+            error::EnvsGateError::InvalidInput("HOME (or USERPROFILE on Windows) not set".into())
+        })
+}
+
 fn torii_home() -> error::Result<String> {
-    let home = std::env::var("HOME")
-        .map_err(|_| error::EnvsGateError::InvalidInput("HOME not set".into()))?;
+    let home = home_dir()?;
     Ok(format!("{home}/.torii"))
 }
 
@@ -67,8 +74,14 @@ fn resolve_paths(
     log_path: &Option<String>,
 ) -> error::Result<(String, String)> {
     if let Some(db) = db_path {
-        // Explicit db-path: ignore namespace
-        let log = log_path.clone().unwrap_or_else(logger::default_log_path);
+        // Explicit db-path: ignore namespace, place audit log next to DB
+        let log = log_path.clone().unwrap_or_else(|| {
+            let db_path = std::path::Path::new(db);
+            let dir = db_path
+                .parent()
+                .unwrap_or_else(|| std::path::Path::new("."));
+            format!("{}/audit.log", dir.display())
+        });
         return Ok((db.clone(), log));
     }
 
@@ -84,8 +97,12 @@ fn resolve_paths(
     {
         use std::os::unix::fs::PermissionsExt;
         let perms = std::fs::Permissions::from_mode(0o700);
-        let _ = std::fs::set_permissions(&torii_home, perms.clone());
-        let _ = std::fs::set_permissions(&ns_dir, perms);
+        if let Err(e) = std::fs::set_permissions(&torii_home, perms.clone()) {
+            eprintln!("Warning: Failed to set permissions on '{torii_home}': {e}");
+        }
+        if let Err(e) = std::fs::set_permissions(&ns_dir, perms) {
+            eprintln!("Warning: Failed to set permissions on '{ns_dir}': {e}");
+        }
     }
 
     let db = format!("{ns_dir}/torii.db");
@@ -1247,8 +1264,17 @@ mod tests {
 
     #[test]
     fn resolve_paths_explicit_db_path_ignores_namespace() {
-        let (db, _log) = resolve_paths(&Some("./custom.db".into()), "myproject", &None).unwrap();
+        let (db, log) = resolve_paths(&Some("./custom.db".into()), "myproject", &None).unwrap();
         assert_eq!(db, "./custom.db");
+        // Log should be placed next to the DB
+        assert_eq!(log, "./audit.log");
+    }
+
+    #[test]
+    fn resolve_paths_explicit_db_path_log_adjacent() {
+        let (_, log) =
+            resolve_paths(&Some("/tmp/mydir/vault.db".into()), "default", &None).unwrap();
+        assert_eq!(log, "/tmp/mydir/audit.log");
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -39,6 +39,11 @@ fn validate_namespace(ns: &str) -> error::Result<()> {
             "Invalid namespace name".into(),
         ));
     }
+    if ns.len() > 64 {
+        return Err(error::EnvsGateError::InvalidInput(
+            "Namespace name must be 64 characters or fewer".into(),
+        ));
+    }
     if !ns
         .chars()
         .all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_')
@@ -73,6 +78,15 @@ fn resolve_paths(
     std::fs::create_dir_all(&ns_dir).map_err(|e| {
         error::EnvsGateError::InvalidInput(format!("Cannot create namespace directory: {e}"))
     })?;
+
+    // Restrict directory permissions to owner only (0o700)
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let perms = std::fs::Permissions::from_mode(0o700);
+        let _ = std::fs::set_permissions(&torii_home, perms.clone());
+        let _ = std::fs::set_permissions(&ns_dir, perms);
+    }
 
     let db = format!("{ns_dir}/torii.db");
 
@@ -1206,6 +1220,29 @@ mod tests {
         assert!(validate_namespace("foo/bar").is_err());
         assert!(validate_namespace("foo bar").is_err());
         assert!(validate_namespace("a@b").is_err());
+        // Length limit
+        assert!(validate_namespace(&"a".repeat(64)).is_ok());
+        assert!(validate_namespace(&"a".repeat(65)).is_err());
+    }
+
+    #[test]
+    fn resolve_paths_sets_directory_permissions() {
+        let dir = tempfile::tempdir().unwrap();
+        let home = dir.path().to_str().unwrap();
+        unsafe { std::env::set_var("HOME", home) };
+
+        resolve_paths(&None, "permtest", &None).unwrap();
+
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let torii_dir = format!("{home}/.torii");
+            let ns_dir = format!("{torii_dir}/permtest");
+            let torii_perms = std::fs::metadata(&torii_dir).unwrap().permissions().mode() & 0o777;
+            let ns_perms = std::fs::metadata(&ns_dir).unwrap().permissions().mode() & 0o777;
+            assert_eq!(torii_perms, 0o700);
+            assert_eq!(ns_perms, 0o700);
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- `--db-path` 未指定時、DBを `~/.torii/<namespace>/torii.db` に保存するよう変更
- `-n` / `--namespace` フラグ追加（デフォルト: `default`）
- `namespaces` コマンド追加（パスワード不要で一覧表示）
- namespace ごとにパスワード・DEKが独立し完全分離
- テスト8件追加（計87件）

## Test plan
- [x] 既存テスト87件全パス
- [x] `torii set K=V` → `~/.torii/default/torii.db` に保存される
- [x] `torii -n myproject set K=V` → `~/.torii/myproject/torii.db` に保存される
- [ ] `torii --db-path ./local.db set K=V` → `./local.db` に保存（namespace 無視）
- [ ] `torii namespaces` → 既存 namespace 一覧表示