### PR TITLE
serve に --timeout オプションを追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,6 +196,12 @@ torii serve -e .env
 torii serve -e .env --once
 ```
 
+最後の読み込みから一定時間後に自動終了（docker compose 等の複数回読み込みに対応）:
+
+```
+torii serve -e .env --timeout 10
+```
+
 Named pipe（FIFO）として指定パスに仮想`.env`ファイルを作成する。
 `cat`やアプリケーションから読み取ると、その瞬間に復号された環境変数が返される。
 ディスクに平文は残らない。Ctrl+Cで停止・パイプ削除。
@@ -204,6 +210,7 @@ Named pipe（FIFO）として指定パスに仮想`.env`ファイルを作成す
 - macOS / Linux 両対応（POSIX標準）
 - 読み取りのたびに動的に復号（キャッシュなし）
 - serve中に期限切れを検出した場合はstderrに警告を出力
+- `--timeout N`: 最後の読み込みからN秒間新たな読み込みがなければ自動終了
 
 #### パスワードローテーション
 
@@ -276,6 +283,7 @@ torii namespaces                      # namespace 一覧表示
 | `--expires <duration>` | 有効期限（`set`時） | なし |
 | `-e, --env-path <path>` | 仮想.envのパス（`serve`時） | `.env` |
 | `--once` | 1回読まれたら終了（`serve`時） | off |
+| `--timeout <seconds>` | 最後の読み込みからN秒で自動終了（`serve`時） | なし |
 
 ## セキュリティ
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -60,7 +60,7 @@ pub enum Commands {
         once: bool,
 
         /// Exit after N seconds of inactivity since last read
-        #[arg(long)]
+        #[arg(long, value_parser = clap::value_parser!(u64).range(1..))]
         timeout: Option<u64>,
     },
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -58,6 +58,10 @@ pub enum Commands {
         /// Exit after the first read
         #[arg(long)]
         once: bool,
+
+        /// Exit after N seconds of inactivity since last read
+        #[arg(long)]
+        timeout: Option<u64>,
     },
 
     /// Execute a command with decrypted environment variables injected

--- a/src/fuse_fs.rs
+++ b/src/fuse_fs.rs
@@ -104,9 +104,11 @@ pub fn serve(
                 Ok(result) => result,
                 Err(_) => {
                     eprintln!("Timeout: no reader for {secs}s, stopping.");
-                    // Remove FIFO to unblock the spawned thread's open() call
-                    let _ = std::fs::remove_file(&path);
+                    // Open FIFO for reading to unblock the spawned thread's
+                    // write-side open(), then remove the FIFO and join.
+                    let _ = std::fs::OpenOptions::new().read(true).open(&path);
                     let _ = handle.join();
+                    let _ = std::fs::remove_file(&path);
                     return Ok(());
                 }
             }

--- a/src/fuse_fs.rs
+++ b/src/fuse_fs.rs
@@ -90,29 +90,28 @@ pub fn serve(
 
     // Loop: each iteration serves one reader
     loop {
-        // FIFO open for writing blocks until a reader connects.
-        // When timeout is set AND at least one read has occurred,
-        // use a background thread so we can time out on inactivity.
+        // Wait for a reader to connect.
+        // When timeout is active (after first read), use O_NONBLOCK + poll
+        // to avoid spawning threads and to make timeout reliably enforceable.
         let file = if let Some(secs) = timeout.filter(|_| has_been_read) {
-            let path_clone = path.clone();
-            let (tx, rx) = std::sync::mpsc::channel();
-            let handle = std::thread::spawn(move || {
-                let result = std::fs::OpenOptions::new().write(true).open(&path_clone);
-                let _ = tx.send(result);
-            });
-            match rx.recv_timeout(std::time::Duration::from_secs(secs)) {
-                Ok(result) => result,
-                Err(_) => {
-                    eprintln!("Timeout: no reader for {secs}s, stopping.");
-                    // Open FIFO for reading to unblock the spawned thread's
-                    // write-side open(), then remove the FIFO and join.
-                    let _ = std::fs::OpenOptions::new().read(true).open(&path);
-                    let _ = handle.join();
-                    let _ = std::fs::remove_file(&path);
-                    return Ok(());
+            let deadline = std::time::Instant::now() + std::time::Duration::from_secs(secs);
+            loop {
+                match open_fifo_nonblock(&path) {
+                    Ok(Some(f)) => break Ok(f),
+                    Ok(None) => {
+                        // No reader yet — check deadline
+                        if std::time::Instant::now() >= deadline {
+                            eprintln!("Timeout: no reader for {secs}s, stopping.");
+                            let _ = std::fs::remove_file(&path);
+                            return Ok(());
+                        }
+                        std::thread::sleep(std::time::Duration::from_millis(100));
+                    }
+                    Err(e) => break Err(e),
                 }
             }
         } else {
+            // Blocking open — waits indefinitely for a reader
             std::fs::OpenOptions::new().write(true).open(&path)
         };
 
@@ -144,4 +143,20 @@ pub fn serve(
     }
 
     Ok(())
+}
+
+/// Try to open a FIFO for writing with O_NONBLOCK.
+/// Returns Ok(Some(file)) if a reader is connected, Ok(None) if ENXIO (no reader yet),
+/// or Err for other failures.
+fn open_fifo_nonblock(path: &Path) -> std::result::Result<Option<std::fs::File>, std::io::Error> {
+    use std::os::unix::fs::OpenOptionsExt;
+    match std::fs::OpenOptions::new()
+        .write(true)
+        .custom_flags(libc::O_NONBLOCK)
+        .open(path)
+    {
+        Ok(f) => Ok(Some(f)),
+        Err(e) if e.raw_os_error() == Some(libc::ENXIO) => Ok(None),
+        Err(e) => Err(e),
+    }
 }

--- a/src/fuse_fs.rs
+++ b/src/fuse_fs.rs
@@ -96,19 +96,17 @@ pub fn serve(
         let file = if let Some(secs) = timeout.filter(|_| has_been_read) {
             let path_clone = path.clone();
             let (tx, rx) = std::sync::mpsc::channel();
-            std::thread::spawn(move || {
+            let handle = std::thread::spawn(move || {
                 let result = std::fs::OpenOptions::new().write(true).open(&path_clone);
                 let _ = tx.send(result);
             });
             match rx.recv_timeout(std::time::Duration::from_secs(secs)) {
                 Ok(result) => result,
-                Err(std::sync::mpsc::RecvTimeoutError::Timeout) => {
+                Err(_) => {
                     eprintln!("Timeout: no reader for {secs}s, stopping.");
+                    // Remove FIFO to unblock the spawned thread's open() call
                     let _ = std::fs::remove_file(&path);
-                    return Ok(());
-                }
-                Err(std::sync::mpsc::RecvTimeoutError::Disconnected) => {
-                    let _ = std::fs::remove_file(&path);
+                    let _ = handle.join();
                     return Ok(());
                 }
             }

--- a/src/fuse_fs.rs
+++ b/src/fuse_fs.rs
@@ -33,7 +33,13 @@ fn generate_env_content(db_path: &str, dek: &[u8; 32]) -> Result<Vec<u8>> {
     Ok(content.into_bytes())
 }
 
-pub fn serve(db_path: &str, dek: &[u8; 32], env_path: &str, once: bool) -> Result<()> {
+pub fn serve(
+    db_path: &str,
+    dek: &[u8; 32],
+    env_path: &str,
+    once: bool,
+    timeout: Option<u64>,
+) -> Result<()> {
     let path = Path::new(env_path);
 
     // Resolve to absolute path
@@ -83,8 +89,26 @@ pub fn serve(db_path: &str, dek: &[u8; 32], env_path: &str, once: bool) -> Resul
 
     // Loop: each iteration serves one reader
     loop {
-        // open for writing blocks until a reader opens the pipe
-        let file = std::fs::OpenOptions::new().write(true).open(&path);
+        // FIFO open for writing blocks until a reader connects.
+        // When timeout is set, use a background thread so we can time out.
+        let file = if let Some(secs) = timeout {
+            let path_clone = path.clone();
+            let (tx, rx) = std::sync::mpsc::channel();
+            std::thread::spawn(move || {
+                let result = std::fs::OpenOptions::new().write(true).open(&path_clone);
+                let _ = tx.send(result);
+            });
+            match rx.recv_timeout(std::time::Duration::from_secs(secs)) {
+                Ok(result) => result,
+                Err(std::sync::mpsc::RecvTimeoutError::Timeout) => {
+                    eprintln!("Timeout: no reader for {secs}s, stopping.");
+                    break;
+                }
+                Err(std::sync::mpsc::RecvTimeoutError::Disconnected) => break,
+            }
+        } else {
+            std::fs::OpenOptions::new().write(true).open(&path)
+        };
 
         match file {
             Ok(mut f) => {

--- a/src/fuse_fs.rs
+++ b/src/fuse_fs.rs
@@ -86,12 +86,14 @@ pub fn serve(
 
     let db_path = db_path.to_string();
     let dek = *dek;
+    let mut has_been_read = false;
 
     // Loop: each iteration serves one reader
     loop {
         // FIFO open for writing blocks until a reader connects.
-        // When timeout is set, use a background thread so we can time out.
-        let file = if let Some(secs) = timeout {
+        // When timeout is set AND at least one read has occurred,
+        // use a background thread so we can time out on inactivity.
+        let file = if let Some(secs) = timeout.filter(|_| has_been_read) {
             let path_clone = path.clone();
             let (tx, rx) = std::sync::mpsc::channel();
             std::thread::spawn(move || {
@@ -102,9 +104,13 @@ pub fn serve(
                 Ok(result) => result,
                 Err(std::sync::mpsc::RecvTimeoutError::Timeout) => {
                     eprintln!("Timeout: no reader for {secs}s, stopping.");
-                    break;
+                    let _ = std::fs::remove_file(&path);
+                    return Ok(());
                 }
-                Err(std::sync::mpsc::RecvTimeoutError::Disconnected) => break,
+                Err(std::sync::mpsc::RecvTimeoutError::Disconnected) => {
+                    let _ = std::fs::remove_file(&path);
+                    return Ok(());
+                }
             }
         } else {
             std::fs::OpenOptions::new().write(true).open(&path)
@@ -112,6 +118,7 @@ pub fn serve(
 
         match file {
             Ok(mut f) => {
+                has_been_read = true;
                 match generate_env_content(&db_path, &dek) {
                     Ok(content) => {
                         let _ = f.write_all(&content);

--- a/src/logger.rs
+++ b/src/logger.rs
@@ -157,8 +157,9 @@ impl Logger {
         self.log(&LogEntry::new("delete", Some(key), None));
     }
 
-    pub fn log_serve(&mut self, env_path: &str, once: bool) {
-        let detail = format!("path={env_path}, once={once}");
+    pub fn log_serve(&mut self, env_path: &str, once: bool, timeout: Option<u64>) {
+        let timeout_str = timeout.map_or("none".into(), |t| format!("{t}s"));
+        let detail = format!("path={env_path}, once={once}, timeout={timeout_str}");
         self.log(&LogEntry::new("serve", None, Some(&detail)));
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -206,9 +206,13 @@ fn main() -> error::Result<()> {
             password.zeroize();
             result?;
         }
-        Some(Commands::Serve { env_path, once }) => {
+        Some(Commands::Serve {
+            env_path,
+            once,
+            timeout,
+        }) => {
             let mut password = prompt_password()?;
-            let result = cmd_serve(&db_path, &password, &env_path, once, &mut log);
+            let result = cmd_serve(&db_path, &password, &env_path, once, timeout, &mut log);
             password.zeroize();
             result?;
         }
@@ -457,6 +461,7 @@ pub fn cmd_serve(
     password: &str,
     env_path: &str,
     once: bool,
+    timeout: Option<u64>,
     log: &mut Option<logger::Logger>,
 ) -> error::Result<()> {
     let conn = db::open_or_create_db(db_path)?;
@@ -480,10 +485,10 @@ pub fn cmd_serve(
     }
 
     if let Some(l) = log {
-        l.log_serve(env_path, once);
+        l.log_serve(env_path, once, timeout);
     }
 
-    fuse_fs::serve(db_path, &dek, env_path, once)
+    fuse_fs::serve(db_path, &dek, env_path, once, timeout)
 }
 
 static CHILD_PID: std::sync::atomic::AtomicI32 = std::sync::atomic::AtomicI32::new(0);

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -142,5 +142,5 @@ fn interactive_serve(db_path: &str, password: &str, log: &mut Option<Logger>) ->
         .interact()
         .map_err(io_err)?;
 
-    cmd_serve(db_path, password, &env_path, once, log)
+    cmd_serve(db_path, password, &env_path, once, None, log)
 }


### PR DESCRIPTION
## Summary
- `--timeout <seconds>`: 最後の読み込みからN秒間新たな読み込みがなければ自動終了
- docker compose 等の複数回 .env 読み込みに対応（`--once` では2回目でブロックされる問題を解決）
- 初回読み込み前はタイムアウトを適用せず、リーダーの接続を無制限に待機
- タイムアウト時は FIFO を削除し、スポーンしたスレッドを明示的に join して終了

## Test plan
- [x] 既存テスト90件全パス
- [x] `torii serve -e .env --timeout 5` → 読み込み後5秒で自動終了、FIFO が削除される
- [x] `torii serve -e .env --timeout 10` → 複数回読み込み可能、最後の読みから10秒で終了
- [x] `torii serve -e .env --once` → 従来通り1回で終了
- [x] `torii serve -e .env` → 従来通り無限ループ

Closes #