### PR TITLE
feat: 対話モードに namespace マージ機能を追加

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1094,6 +1094,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2",
+ "shell-words",
  "tempfile",
  "thiserror 2.0.18",
  "x25519-dalek",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,3 +37,4 @@ libc = "0.2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 tempfile = "3"
+shell-words = "1"

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -461,13 +461,12 @@ pub fn cmd_exec(
         .unwrap_or_else(|| status.signal().map_or(1, |sig| 128 + sig)))
 }
 
-pub fn cmd_namespaces() -> error::Result<()> {
+pub fn list_namespace_names() -> error::Result<Vec<String>> {
     let torii_home = torii_home()?;
     let path = std::path::Path::new(&torii_home);
 
     if !path.exists() {
-        eprintln!("No namespaces found.");
-        return Ok(());
+        return Ok(Vec::new());
     }
 
     let mut entries: Vec<String> = std::fs::read_dir(path)
@@ -480,6 +479,11 @@ pub fn cmd_namespaces() -> error::Result<()> {
         .filter_map(|e| e.file_name().into_string().ok())
         .collect();
     entries.sort();
+    Ok(entries)
+}
+
+pub fn cmd_namespaces() -> error::Result<()> {
+    let entries = list_namespace_names()?;
 
     if entries.is_empty() {
         eprintln!("No namespaces found.");
@@ -494,6 +498,89 @@ pub fn cmd_namespaces() -> error::Result<()> {
     }
 
     Ok(())
+}
+
+/// Decrypt all non-expired environment variables from a namespace DB.
+/// Returns Vec of (key, plaintext_value, expires_at).
+pub fn decrypt_all_vars(
+    db_path: &str,
+    password: &str,
+    log: &mut Option<logger::Logger>,
+) -> error::Result<Vec<(String, String, Option<String>)>> {
+    let conn = db::open_or_create_db(db_path)?;
+    let meta = db::load_metadata(&conn)?
+        .ok_or_else(|| error::EnvsGateError::InvalidInput("Database not initialized".into()))?;
+    let dek = unwrap_dek_logged(password, &meta, log)?;
+
+    let vars = db::list_env_vars(&conn)?;
+    let mut result = Vec::new();
+
+    for var in &vars {
+        if let Some(ref exp) = var.expires_at
+            && is_expired(exp)
+        {
+            eprintln!("Warning: {} expired at {}, skipping", var.key_name, exp);
+            continue;
+        }
+
+        let plaintext = crypto::decrypt_value(&dek, &var.nonce, &var.ciphertext)?;
+        let value = String::from_utf8(plaintext).map_err(|e| {
+            let mut bytes = e.into_bytes();
+            bytes.zeroize();
+            error::EnvsGateError::InvalidInput(format!(
+                "Value for '{}' contains invalid UTF-8",
+                var.key_name
+            ))
+        })?;
+        result.push((var.key_name.clone(), value, var.expires_at.clone()));
+    }
+
+    Ok(result)
+}
+
+/// Execute a command with pre-built environment variable pairs.
+pub fn exec_with_env(
+    command: &[String],
+    env_pairs: Vec<(String, String)>,
+    log: &mut Option<logger::Logger>,
+) -> error::Result<i32> {
+    if command.is_empty() {
+        return Err(error::EnvsGateError::InvalidInput(
+            "No command specified".into(),
+        ));
+    }
+
+    if let Some(l) = log {
+        l.log_exec(&command[0], env_pairs.len());
+    }
+
+    let program = &command[0];
+    let args = &command[1..];
+
+    install_signal_forwarder();
+
+    let mut child = std::process::Command::new(program)
+        .args(args)
+        .envs(env_pairs.iter().map(|(k, v)| (k.as_str(), v.as_str())))
+        .spawn()
+        .map_err(|e| {
+            error::EnvsGateError::InvalidInput(format!("Failed to execute '{program}': {e}"))
+        })?;
+
+    for (_, mut val) in env_pairs {
+        val.zeroize();
+    }
+
+    CHILD_PID.store(child.id() as i32, std::sync::atomic::Ordering::SeqCst);
+
+    let status = child.wait().map_err(|e| {
+        error::EnvsGateError::InvalidInput(format!("Failed to wait for child process: {e}"))
+    })?;
+
+    use std::os::unix::process::ExitStatusExt;
+    Ok(status
+        .code()
+        .unwrap_or_else(|| status.signal().map_or(1, |sig| 128 + sig)))
 }
 
 pub fn cmd_rotate_password(

--- a/src/fuse_fs.rs
+++ b/src/fuse_fs.rs
@@ -145,6 +145,98 @@ pub fn serve(
     Ok(())
 }
 
+/// Serve pre-built .env content via named pipe.
+pub fn serve_content(
+    content: &str,
+    env_path: &str,
+    once: bool,
+    timeout: Option<u64>,
+) -> Result<()> {
+    let path = Path::new(env_path);
+
+    let path = if path.is_relative() {
+        std::env::current_dir()
+            .map_err(|e| EnvsGateError::Fuse(format!("Cannot get cwd: {e}")))?
+            .join(path)
+    } else {
+        path.to_path_buf()
+    };
+
+    let path_cstr = std::ffi::CString::new(path.to_str().unwrap())
+        .map_err(|e| EnvsGateError::Fuse(format!("Invalid path: {e}")))?;
+
+    let _ = std::fs::remove_file(&path);
+    let ret = unsafe { libc::mkfifo(path_cstr.as_ptr(), 0o600) };
+    if ret != 0 {
+        let err = std::io::Error::last_os_error();
+        if err.raw_os_error() == Some(libc::EEXIST) {
+            return Err(EnvsGateError::Fuse(format!(
+                "File already exists at {}",
+                path.display()
+            )));
+        }
+        return Err(EnvsGateError::Fuse(format!(
+            "mkfifo failed at {}: {}",
+            path.display(),
+            err
+        )));
+    }
+
+    eprintln!("Serving virtual .env at: {}", path.display());
+    eprintln!("Press Ctrl+C to stop");
+
+    let path_clone = path.clone();
+    ctrlc::set_handler(move || {
+        let _ = std::fs::remove_file(&path_clone);
+        eprintln!("\nStopped.");
+        std::process::exit(0);
+    })
+    .map_err(|e| EnvsGateError::Fuse(format!("Cannot set Ctrl+C handler: {e}")))?;
+
+    let content_bytes = content.as_bytes();
+    let mut has_been_read = false;
+
+    loop {
+        let file = if let Some(secs) = timeout.filter(|_| has_been_read) {
+            let deadline = std::time::Instant::now() + std::time::Duration::from_secs(secs);
+            loop {
+                match open_fifo_nonblock(&path) {
+                    Ok(Some(f)) => break Ok(f),
+                    Ok(None) => {
+                        if std::time::Instant::now() >= deadline {
+                            eprintln!("Timeout: no reader for {secs}s, stopping.");
+                            let _ = std::fs::remove_file(&path);
+                            return Ok(());
+                        }
+                        std::thread::sleep(std::time::Duration::from_millis(100));
+                    }
+                    Err(e) => break Err(e),
+                }
+            }
+        } else {
+            std::fs::OpenOptions::new().write(true).open(&path)
+        };
+
+        match file {
+            Ok(mut f) => {
+                has_been_read = true;
+                let _ = f.write_all(content_bytes);
+                if once {
+                    break;
+                }
+            }
+            Err(e) => {
+                if !path.exists() {
+                    break;
+                }
+                eprintln!("Warning: pipe open failed: {e}");
+            }
+        }
+    }
+
+    Ok(())
+}
+
 /// Try to open a FIFO for writing with O_NONBLOCK.
 /// Returns Ok(Some(file)) if a reader is connected, Ok(None) if ENXIO (no reader yet),
 /// or Err for other failures.

--- a/src/logger.rs
+++ b/src/logger.rs
@@ -182,6 +182,11 @@ impl Logger {
         self.log(&LogEntry::new("rotate_dek", None, Some(&detail)));
     }
 
+    pub fn log_merge(&mut self, ns_a: &str, ns_b: &str, total: usize, conflicts: usize) {
+        let detail = format!("ns_a={ns_a}, ns_b={ns_b}, total={total}, conflicts={conflicts}");
+        self.log(&LogEntry::new("merge", None, Some(&detail)));
+    }
+
     pub fn log_auth_failed(&mut self) {
         self.log(&LogEntry::new("auth_failed", None, None));
     }

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -221,10 +221,7 @@ fn interactive_merge(log: &mut Option<Logger>) -> Result<()> {
                 } else {
                     conflict_count += 1;
                     eprintln!("\nConflict: {key}");
-                    let choices = &[
-                        format!("[{ns_a}] {val_a}"),
-                        format!("[{ns_b}] {val_b}"),
-                    ];
+                    let choices = &[format!("[{ns_a}] {val_a}"), format!("[{ns_b}] {val_b}")];
                     let pick = Select::new()
                         .with_prompt(format!("Which value for '{key}'?"))
                         .items(choices)
@@ -252,11 +249,7 @@ fn interactive_merge(log: &mut Option<Logger>) -> Result<()> {
     }
 
     // 出力方式を選択
-    let output_modes = &[
-        "Print to stdout",
-        "Serve virtual .env",
-        "Execute command",
-    ];
+    let output_modes = &["Print to stdout", "Serve virtual .env", "Execute command"];
     let mode = Select::new()
         .with_prompt("Output")
         .items(output_modes)
@@ -308,9 +301,8 @@ fn interactive_merge(log: &mut Option<Logger>) -> Result<()> {
                 .interact_text()
                 .map_err(io_err)?;
 
-            let command: Vec<String> = shell_words::split(&cmd_str).map_err(|e| {
-                EnvsGateError::InvalidInput(format!("Invalid command: {e}"))
-            })?;
+            let command: Vec<String> = shell_words::split(&cmd_str)
+                .map_err(|e| EnvsGateError::InvalidInput(format!("Invalid command: {e}")))?;
 
             let code = exec_with_env(&command, merged, log)?;
             eprintln!("Exit code: {code}");

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -1,7 +1,14 @@
-use dialoguer::{Confirm, Input, Password, Select};
+use std::collections::{BTreeMap, BTreeSet};
 
-use crate::commands::{cmd_delete, cmd_get, cmd_list, cmd_serve, cmd_set};
+use dialoguer::{Confirm, Input, Password, Select};
+use zeroize::Zeroize;
+
+use crate::commands::{
+    cmd_delete, cmd_get, cmd_list, cmd_serve, cmd_set, decrypt_all_vars, exec_with_env,
+    list_namespace_names, resolve_paths,
+};
 use crate::error::{EnvsGateError, Result};
+use crate::fuse_fs;
 use crate::logger::Logger;
 use crate::{crypto, db};
 
@@ -40,6 +47,7 @@ pub fn run_interactive(db_path: &str, log_path: Option<&str>) -> Result<()> {
             "List all variables",
             "Delete environment variable",
             "Serve virtual .env",
+            "Merge namespaces",
             "Exit",
         ];
 
@@ -56,7 +64,8 @@ pub fn run_interactive(db_path: &str, log_path: Option<&str>) -> Result<()> {
             2 => cmd_list(db_path, &password, &mut log),
             3 => interactive_delete(db_path, &password, &mut log),
             4 => interactive_serve(db_path, &password, &mut log),
-            5 => break,
+            5 => interactive_merge(&mut log),
+            6 => break,
             _ => unreachable!(),
         };
 
@@ -128,6 +137,188 @@ fn interactive_delete(db_path: &str, password: &str, log: &mut Option<Logger>) -
         eprintln!("Cancelled.");
         Ok(())
     }
+}
+
+fn interactive_merge(log: &mut Option<Logger>) -> Result<()> {
+    let namespaces = list_namespace_names()?;
+    if namespaces.len() < 2 {
+        eprintln!("Namespace が 2 つ以上必要です。");
+        return Ok(());
+    }
+
+    // namespace A を選択
+    let idx_a = Select::new()
+        .with_prompt("Namespace A")
+        .items(&namespaces)
+        .default(0)
+        .interact()
+        .map_err(io_err)?;
+
+    // namespace B を選択（A と同じものは除外）
+    let ns_b_items: Vec<&String> = namespaces
+        .iter()
+        .enumerate()
+        .filter(|(i, _)| *i != idx_a)
+        .map(|(_, n)| n)
+        .collect();
+    let idx_b = Select::new()
+        .with_prompt("Namespace B")
+        .items(&ns_b_items)
+        .default(0)
+        .interact()
+        .map_err(io_err)?;
+
+    let ns_a = &namespaces[idx_a];
+    let ns_b = ns_b_items[idx_b];
+
+    // パスを解決
+    let (db_a, _) = resolve_paths(&None, ns_a, &None)?;
+    let (db_b, _) = resolve_paths(&None, ns_b, &None)?;
+
+    // パスワード入力
+    let pw_a: String = Password::new()
+        .with_prompt(format!("Password for '{ns_a}'"))
+        .interact()
+        .map_err(io_err)?;
+
+    let pw_b: String = Password::new()
+        .with_prompt(format!("Password for '{ns_b}'"))
+        .interact()
+        .map_err(io_err)?;
+
+    // 両方の環境変数を復号
+    let vars_a = decrypt_all_vars(&db_a, &pw_a, log)?;
+    let vars_b = decrypt_all_vars(&db_b, &pw_b, log)?;
+
+    // マージ: BTreeMap で管理（キー順ソート）
+    let map_a: BTreeMap<&str, (&str, Option<&str>)> = vars_a
+        .iter()
+        .map(|(k, v, e)| (k.as_str(), (v.as_str(), e.as_deref())))
+        .collect();
+    let map_b: BTreeMap<&str, (&str, Option<&str>)> = vars_b
+        .iter()
+        .map(|(k, v, e)| (k.as_str(), (v.as_str(), e.as_deref())))
+        .collect();
+
+    // 全キーを収集
+    let all_keys: BTreeSet<&str> = map_a.keys().chain(map_b.keys()).copied().collect();
+
+    let mut merged: Vec<(String, String)> = Vec::new();
+    let mut conflict_count = 0;
+
+    for key in &all_keys {
+        match (map_a.get(key), map_b.get(key)) {
+            (Some((val, _)), None) => {
+                merged.push((key.to_string(), val.to_string()));
+            }
+            (None, Some((val, _))) => {
+                merged.push((key.to_string(), val.to_string()));
+            }
+            (Some((val_a, _)), Some((val_b, _))) => {
+                if val_a == val_b {
+                    // 値が同じならそのまま
+                    merged.push((key.to_string(), val_a.to_string()));
+                } else {
+                    conflict_count += 1;
+                    eprintln!("\nConflict: {key}");
+                    let choices = &[
+                        format!("[{ns_a}] {val_a}"),
+                        format!("[{ns_b}] {val_b}"),
+                    ];
+                    let pick = Select::new()
+                        .with_prompt(format!("Which value for '{key}'?"))
+                        .items(choices)
+                        .default(0)
+                        .interact()
+                        .map_err(io_err)?;
+                    let chosen = if pick == 0 { val_a } else { val_b };
+                    merged.push((key.to_string(), chosen.to_string()));
+                }
+            }
+            (None, None) => unreachable!(),
+        }
+    }
+
+    eprintln!(
+        "\nMerged: {} keys ({} from '{ns_a}', {} from '{ns_b}', {} conflicts)",
+        merged.len(),
+        map_a.len(),
+        map_b.len(),
+        conflict_count,
+    );
+
+    if let Some(l) = log {
+        l.log_merge(ns_a, ns_b, merged.len(), conflict_count);
+    }
+
+    // 出力方式を選択
+    let output_modes = &[
+        "Print to stdout",
+        "Serve virtual .env",
+        "Execute command",
+    ];
+    let mode = Select::new()
+        .with_prompt("Output")
+        .items(output_modes)
+        .default(0)
+        .interact()
+        .map_err(io_err)?;
+
+    match mode {
+        0 => {
+            // stdout
+            for (k, v) in &merged {
+                println!("{k}={v}");
+            }
+            // zeroize
+            for (_, mut v) in merged {
+                v.zeroize();
+            }
+        }
+        1 => {
+            // serve
+            let env_path: String = Input::new()
+                .with_prompt(".env path")
+                .default(".env".into())
+                .interact_text()
+                .map_err(io_err)?;
+
+            let once = Confirm::new()
+                .with_prompt("Exit after first read?")
+                .default(true)
+                .interact()
+                .map_err(io_err)?;
+
+            let mut content = String::new();
+            for (k, v) in &merged {
+                content.push_str(&format!("{k}={v}\n"));
+            }
+
+            for (_, mut v) in merged {
+                v.zeroize();
+            }
+
+            fuse_fs::serve_content(&content, &env_path, once, None)?;
+            content.zeroize();
+        }
+        2 => {
+            // exec
+            let cmd_str: String = Input::new()
+                .with_prompt("Command")
+                .interact_text()
+                .map_err(io_err)?;
+
+            let command: Vec<String> = shell_words::split(&cmd_str).map_err(|e| {
+                EnvsGateError::InvalidInput(format!("Invalid command: {e}"))
+            })?;
+
+            let code = exec_with_env(&command, merged, log)?;
+            eprintln!("Exit code: {code}");
+        }
+        _ => unreachable!(),
+    }
+
+    Ok(())
 }
 
 fn interactive_serve(db_path: &str, password: &str, log: &mut Option<Logger>) -> Result<()> {


### PR DESCRIPTION
## Summary
- 2つの namespace の環境変数を復号・マージし、1つの `.env` として出力する機能を TUI に追加
- キーが競合する場合、どちらの namespace の値を使うか対話的に選択可能
- 出力方式は stdout / serve（FIFO）/ exec（コマンド注入）の3種類に対応

## 変更内容
- `src/tui.rs`: メニューに「Merge namespaces」追加、`interactive_merge()` 実装
- `src/commands.rs`: `list_namespace_names()`, `decrypt_all_vars()`, `exec_with_env()` ヘルパー追加
- `src/fuse_fs.rs`: `serve_content()` 追加（事前構築済みコンテンツの FIFO 配信）
- `src/logger.rs`: `log_merge()` 監査ログ追加
- `Cargo.toml`: `shell-words` 依存追加

## Test plan
- [ ] `cargo test` 全テスト通過確認
- [ ] `cargo clippy --all-targets` 警告なし確認
- [ ] 2つの namespace を作成し、対話モードで Merge namespaces を実行
- [ ] キー競合時に選択UIが表示されることを確認
- [ ] stdout / serve / exec の各出力方式で正しくマージ結果が出力されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)